### PR TITLE
build(release): Go modules for ContinuumLLC fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ How to use
 ----------
 
 ```go
-import "github.com/afex/hystrix-go/hystrix"
+import "github.com/ContinuumLLC/hystrix-go/hystrix"
 ```
 
 ### Execute code as a Hystrix command
@@ -141,5 +141,5 @@ Build and Test
 - Install vagrant and VirtualBox
 - Clone the hystrix-go repository
 - Inside the hystrix-go directory, run ```vagrant up```, then ```vagrant ssh```
-- ```cd /go/src/github.com/afex/hystrix-go```
+- ```cd /go/src/github.com/ContinuumLLC/hystrix-go```
 - ```go test ./...```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure("2") do |config|
 
 	config.vm.provision :shell, :path => "scripts/vagrant.sh"
 	
-	config.vm.synced_folder ".", "/go/src/github.com/afex/hystrix-go"
+	config.vm.synced_folder ".", "/go/src/github.com/ContinuumLLC/hystrix-go"
 
 	config.vm.provider "virtualbox" do |v|
 		v.cpus = 3

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/afex/hystrix-go
+module github.com/ContinuumLLC/hystrix-go
 
 go 1.15
 
@@ -9,5 +9,3 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1 // indirect
 )
-
-replace github.com/afex/hystrix-go => github.com/ContinuumLLC/hystrix-go v1.0.1

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix/callback"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/callback"
 )
 
 // CircuitBreaker is created for each ExecutorPool to track whether requests

--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix/rolling"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/rolling"
 )
 
 const (

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -3,7 +3,7 @@ package metricCollector
 import (
 	"sync"
 
-	"github.com/afex/hystrix-go/hystrix/rolling"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/rolling"
 )
 
 // DefaultMetricCollector holds information about the circuit state.

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix/metric_collector"
-	"github.com/afex/hystrix-go/hystrix/rolling"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/metric_collector"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/rolling"
 )
 
 type commandExecution struct {

--- a/hystrix/pool_metrics.go
+++ b/hystrix/pool_metrics.go
@@ -3,7 +3,7 @@ package hystrix
 import (
 	"sync"
 
-	"github.com/afex/hystrix-go/hystrix/rolling"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/rolling"
 )
 
 type poolMetrics struct {

--- a/loadtest/service/main.go
+++ b/loadtest/service/main.go
@@ -11,9 +11,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix"
-	"github.com/afex/hystrix-go/hystrix/metric_collector"
-	"github.com/afex/hystrix-go/plugins"
+	"github.com/ContinuumLLC/hystrix-go/hystrix"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/metric_collector"
+	"github.com/ContinuumLLC/hystrix-go/plugins"
 	"github.com/cactus/go-statsd-client/statsd"
 )
 

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -4,7 +4,7 @@ import (
 
 	// Developed on https://github.com/DataDog/datadog-go/tree/a27810dd518c69be741a7fd5d0e39f674f615be8
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/metric_collector"
 )
 
 // These metrics are constants because we're leveraging the Datadog tagging
@@ -75,8 +75,8 @@ type (
 //  package main
 //
 //  import (
-//  	"github.com/afex/hystrix-go/plugins"
-//  	"github.com/afex/hystrix-go/hystrix/metric_collector"
+//  	"github.com/ContinuumLLC/hystrix-go/plugins"
+//  	"github.com/ContinuumLLC/hystrix-go/hystrix/metric_collector"
 //  )
 //
 //  func main() {

--- a/plugins/graphite_aggregator.go
+++ b/plugins/graphite_aggregator.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/metric_collector"
 	"github.com/rcrowley/go-metrics"
 )
 

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/ContinuumLLC/hystrix-go/hystrix/metric_collector"
 	"github.com/cactus/go-statsd-client/statsd"
 )
 

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-wget -q https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.9.4.linux-amd64.tar.gz
+wget -q https://storage.googleapis.com/golang/go1.15.11.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.15.11.linux-amd64.tar.gz
 
 apt-get update
 apt-get -y install git mercurial apache2-utils
@@ -12,13 +12,14 @@ export GOPATH=/go' >> /home/vagrant/.profile
 
 source /home/vagrant/.profile
 
+chown -R vagrant:vagrant /go
+
 go get golang.org/x/tools/cmd/goimports
-go get github.com/golang/lint/golint
+go get -u golang.org/x/lint/golint
 go get github.com/smartystreets/goconvey/convey
 go get github.com/cactus/go-statsd-client/statsd
 go get github.com/rcrowley/go-metrics
 go get github.com/DataDog/datadog-go/statsd
 
-chown -R vagrant:vagrant /go
 
-echo "cd /go/src/github.com/afex/hystrix-go" >> /home/vagrant/.bashrc
+echo "cd /go/src/github.com/ContinuumLLC/hystrix-go" >> /home/vagrant/.bashrc


### PR DESCRIPTION
1) Change import path for all *.go
2) Change README.md for import path examples
3) Change go.mod to use ContinuumLLC fork
4) Change Vagrant file for development
5) Updated Vagrant script to use Go 1.15.11
6) Fixed Vagrant provisioning script